### PR TITLE
Fix mobile view again

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Snake WebAssembly HTML5 Canvas</title>
     <style>
         body {
-            overflow-y: hidden;
+            overflow: hidden;
         }
         @font-face {
             font-family: AnekLatin;
@@ -15,8 +15,18 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            height: 100%;
             touch-action: none;
+            object-fit: scale-down;
+        }
+        @media (orientation: portrait) {
+            #app {
+                width: 100%;
+            }
+        }
+        @media (orientation: landscape) {
+            #app {
+                height: 100%;
+            }
         }
     </style>
   </head>


### PR DESCRIPTION
@rexim I'm sorry, but it seems my PR #4 didn't quite fix the problem on some different browsers/devices. So here is another fix.

- The overflow-y seems not to work on iOS
- Fix not visible areas of canvas by respecting the orientation

This time I tested the changes on Android (Firefox/Chrome) and iOS (Safari/Chrome).