### PR TITLE
add plan9 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ $ python -m http.server 6969
 $ iexplore.exe http://localhost:6969/
 ```
 
+### Running plan9 version
+```rc
+% ape/sh build.sh
+% plan9_main
+```
+
 ## Font
 
 [Anek Latin Light](https://github.com/EkType/Anek)

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,17 @@
 
 set -xe
 
-# plan9
 if [ -d /acme ]; then
+  # compiling on plan9
   pcc -c game.c
   6c plan9_main.c
   6l -o plan9_main game.6 plan9_main.6 -lttf -lbio
+  exit 0
+else
+  # compiling on unix - using plan9port for graphics (https://9fans.github.io/plan9port/)
+  9c game.c
+  9c plan9_main.c
+  9l -o plan9port_main game.o plan9_main.o
   exit 0
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,14 @@
 
 set -xe
 
+# plan9
+if [ -d /acme ]; then
+  pcc -c game.c
+  6c plan9_main.c
+  6l -o plan9_main game.6 plan9_main.6 -lttf -lbio
+  exit 0
+fi
+
 clang -Wall -Wextra -Wswitch-enum -c game.c
 clang -Wall -Wextra -Wswitch-enum -o sdl_main sdl_main.c game.o -lSDL2 -lSDL2_ttf -lm
 clang -Wall -Wextra -Wswitch-enum -I./include/ -o raylib_main raylib_main.c game.o -L./lib/ -lraylib -lm

--- a/game.c
+++ b/game.c
@@ -1,7 +1,7 @@
 #include "./game.h"
 
 // #define FEATURE_DYNAMIC_CAMERA
-#define FEATURE_DEV
+// #define FEATURE_DEV
 
 #define STB_SPRINTF_IMPLEMENTATION
 #include "stb_sprintf.h"
@@ -413,8 +413,8 @@ static Dir cells_dir(Cell a, Cell b)
 static Vec cell_center(Cell a)
 {
     return (Vec) {
-        .x = a.x*CELL_SIZE + CELL_SIZE/2,
-        .y = a.y*CELL_SIZE + CELL_SIZE/2,
+        a.x*CELL_SIZE + CELL_SIZE/2,
+        a.y*CELL_SIZE + CELL_SIZE/2,
     };
 }
 
@@ -429,8 +429,8 @@ static Sides slide_sides(Sides sides, Dir dir, f32 a)
 Vec sides_center(Sides sides)
 {
     return (Vec) {
-        .x = sides.lens[DIR_LEFT] + (sides.lens[DIR_RIGHT] - sides.lens[DIR_LEFT])*0.5f,
-        .y = sides.lens[DIR_UP] + (sides.lens[DIR_DOWN] - sides.lens[DIR_UP])*0.5f,
+        sides.lens[DIR_LEFT] + (sides.lens[DIR_RIGHT] - sides.lens[DIR_LEFT])*0.5f,
+        sides.lens[DIR_UP] + (sides.lens[DIR_DOWN] - sides.lens[DIR_UP])*0.5f,
     };
 }
 
@@ -702,8 +702,8 @@ void game_keydown(int key)
 static Vec vec_sub(Vec a, Vec b)
 {
     return (Vec) {
-        .x = a.x - b.x,
-        .y = a.y - b.y,
+        a.x - b.x,
+        a.y - b.y,
     };
 }
 

--- a/game.h
+++ b/game.h
@@ -1,7 +1,9 @@
 #ifndef GAME_H_
 #define GAME_H_
 
+#ifndef PLAN9
 #include <stddef.h>
+#endif
 
 typedef unsigned char u8;
 typedef unsigned int u32;

--- a/plan9_main.c
+++ b/plan9_main.c
@@ -5,7 +5,7 @@
 #include <cursor.h>
 #include <event.h>
 #include <bio.h>
-#include <ttf.h>
+/* #include <ttf.h> */
 
 #define PLAN9
 #include "game.h"

--- a/plan9_main.c
+++ b/plan9_main.c
@@ -1,0 +1,121 @@
+#include <u.h>
+#include <libc.h>
+
+#include <draw.h>
+#include <cursor.h>
+#include <event.h>
+#include <bio.h>
+#include <ttf.h>
+
+#define PLAN9
+#include "game.h"
+
+#define FACTOR 100
+#define WIDTH (16*FACTOR)
+#define HEIGHT (9*FACTOR)
+
+#define color2color(color) \
+ (((color>>0)&0xff)<<24)| \
+ (((color>>8)&0xff)<<16)| \
+ (((color>>16)&0xff)<<8)| \
+ (((color>>24)&0xff)<<0)
+
+static int xr, yr;
+//static TTFont *ttf_font;
+
+void
+platform_fill_rect(i32 x, i32 y, i32 w, i32 h, u32 color)
+{
+  Image *tmp_img = allocimage(display, Rect(0, 0, 1, 1), RGB24, 1, color2color(color));
+  draw(screen, Rect(xr+x, yr+y, xr+x+w, yr+y+h), tmp_img, nil, ZP);
+}
+
+void
+platform_stroke_rect(i32 x, i32 y, i32 w, i32 h, u32 color)
+{
+  Image *tmp_img = allocimage(display, Rect(0, 0, 1, 1), RGB24, 1, color2color(color));
+  line(screen, Pt(x+xr, y+yr), Pt(x+xr+w, y+h+yr), 0, 0, 0, tmp_img, ZP);
+  line(screen, Pt(x+xr, y+yr), Pt(x+xr, y+h+yr), 0, 0, 0, tmp_img, ZP);
+  line(screen, Pt(x+w+xr, y+yr), Pt(x+xr+w, y+h+yr), 0, 0, 0, tmp_img, ZP);
+  line(screen, Pt(x+xr, y+h+yr), Pt(x+xr+w, y+h+yr), 0, 0, 0, tmp_img, ZP);
+}
+
+u32
+platform_text_width(const char *text, u32 size)
+{
+  return strlen(text) * 8;
+}
+
+void
+platform_fill_text(i32 x, i32 y, const char *text, u32 fontSize, u32 color)
+{
+  Image *tmp_img = allocimage(display, Rect(0, 0, 1, 1), RGB24, 1, color2color(color));
+  Point pt = string(screen, Pt(xr + x, yr + y), tmp_img, ZP, font, text);
+}
+
+void
+platform_panic(const char *file_path, i32 line, const char *message)
+{
+  sysfatal("%s:%d: GAME ASSERTION FAILED: %s\n", file_path, line, message);
+}
+
+void
+platform_log(const char *message)
+{
+  (void)message;
+}
+
+void
+eresized(int new)
+{
+  if (new && getwindow(display, Refnone) < 0)
+    fprint(1, "can't reattach window");
+
+  xr = screen->r.min.x, yr = screen->r.min.y;
+}
+
+void
+resize(int x, int y, int w, int h)
+{
+  int wctl = open("/dev/wctl", ORDWR);
+  fprint(wctl, "resize -r %d %d %d %d\n", x, y, x+w, x+h);
+  close(wctl);
+
+  eresized(69);
+}
+
+int
+main(int argc, char **argv)
+{
+  if (initdraw(nil, nil, argv0) < 0)
+    perror(argv0);
+
+  einit(Ekeyboard);
+
+  resize(100, 100, WIDTH, HEIGHT);
+  game_init(WIDTH, HEIGHT);
+
+  vlong last = nsec();
+  float dt = 0;
+  while (1) {
+    last = nsec();
+    if (ecankbd()) {
+      int k = ekbd();
+      if (k == 'q')
+        exits(argv0);
+      game_keydown(k);
+    }
+
+    game_update(dt);
+    game_render();
+    /*
+     char s[512];
+     sprint(s, "%f", dt);
+     platform_fill_text(200, 200, s, 1, 0xffffffff);
+    */
+    flushimage(display, Refnone);
+    dt = (nsec() - last)/1000000000.0;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This commit adds a Plan9 platform.
This was only tested on [9front](http://9front.org).

It doesn't use the font because of a bug in 9front's [libttf](http://git.9front.org/plan9front/plan9front/abdb62608209861e52798c1225d8779c5cd96196/sys/src/libttf/hint.c/f.html).

```c
static void
push(Hint *h, u32int w)
{
	assert(h->sp < h->nstack); // ← fails on that assert when trying to load the font
	h->stack[h->sp++] = w;
}
```

I know adding-as-much-platforms-as-possible is probably *not* the main idea of this repo, but it demonstrates how easy implementing a platform for the game on a completely different system actually is.

It also messes in a small way with `game.c`, because 9fronts' `pcc` (a posix-compatible c compiler) doesn't implement ~~this GNU extension~~ **designated initializers in compound literals**:

```c
Type thing = (Type) { .foo = 69, .bar = 420 };
```

so i changed that to

```c
Type thing = (Type) { 69, 420 };
```

https://github.com/tsoding/snake-c-wasm/assets/76700379/5d51e151-fc78-482e-9994-535a60ef6f56